### PR TITLE
tagSlugs method

### DIFF
--- a/src/Conner/Tagging/TaggableTrait.php
+++ b/src/Conner/Tagging/TaggableTrait.php
@@ -45,6 +45,22 @@ trait TaggableTrait {
 		
 		return $tagNames;
 	}
+
+	/**
+	 * Return array of the tag slugs related to the current model
+	 *
+	 * @return array
+	 */
+	public function tagSlugs() {
+		$tagSlugs = array();
+		$tagged = $this->tagged()->get(array('tag_slug'));
+
+		foreach($tagged as $tagged) {
+			$tagSlugs[] = $tagged->tag_slug;
+		}
+		
+		return $tagSlugs;
+	}
 	
 	/**
 	 * Remove the tag from this model


### PR DESCRIPTION
Useful when checking for tags in a loop.

For example, I needed to use this in combination with Chosen (http://harvesthq.github.io/chosen/) to highlight tags selected on an article. Because tagNames gives a Str::title'd version as saved in the table, this can't be done cleanly.
