### PR TITLE
Update composer.json to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "rtconner/laravel-tagging",
 	"description": "Use PHP traits to extend Laravel Eloquent Models to allow Tags. Models can be marked as Taggable.",
 	"license": "MIT",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"homepage": "https://smartersoftware.net/packages/laravel-tagging-taggable",
 	"keywords": ["tag", "tags", "tagging", "laravel", "taggable", "tagged", "eloquent", "laravel5"],
 	"authors": [


### PR DESCRIPTION
Looks like there was a version bump but it wasn't tagged correctly?  
[Packagist](https://packagist.org/packages/rtconner/laravel-tagging) only shows 1.0.0 as well.  

As a side note: the issue [here](https://github.com/rtconner/laravel-tagging/issues/31) said that he had to manually pull in the migrations. I believe this is because publishing the migrations were added in 1.0.1 which is available for download.