### PR TITLE
Use the time the user published migrations

### DIFF
--- a/src/Conner/Tagging/TaggingServiceProvider.php
+++ b/src/Conner/Tagging/TaggingServiceProvider.php
@@ -18,8 +18,8 @@ class TaggingServiceProvider extends ServiceProvider {
 	public function boot() {
 		$this->publishes([
 			__DIR__.'/../../../config/tagging.php' => config_path('tagging.php'),
-			__DIR__.'/../../../migrations/2014_01_07_073615_create_tagged_table.php' => base_path('database/migrations/2014_01_07_073615_create_tagged_table.php'),
-			__DIR__.'/../../../migrations/2014_01_07_073615_create_tags_table.php' => base_path('database/migrations/2014_01_07_073615_create_tags_table.php'),
+			__DIR__.'/../../../migrations/2014_01_07_073615_create_tagged_table.php' => base_path('database/migrations/' . date('Y_m_d_His') . '_create_tagged_table.php'),
+			__DIR__.'/../../../migrations/2014_01_07_073615_create_tags_table.php' => base_path('database/migrations/' . date('Y_m_d_His') . '_create_tags_table.php'),
 		]);
 	}
 	


### PR DESCRIPTION
Using the current date and time means this package's migrations will be created in sequence with their other migrations the user has created.