### PR TITLE
Changed Base path to databasePath while Publishing Migration files in boot()

### DIFF
--- a/src/Conner/Tagging/TaggingServiceProvider.php
+++ b/src/Conner/Tagging/TaggingServiceProvider.php
@@ -18,8 +18,8 @@ class TaggingServiceProvider extends ServiceProvider {
 	public function boot() {
 		$this->publishes([
 			__DIR__.'/../../../config/tagging.php' => config_path('tagging.php'),
-			__DIR__.'/../../../migrations/2014_01_07_073615_create_tagged_table.php' => base_path('database/migrations/2014_01_07_073615_create_tagged_table.php'),
-			__DIR__.'/../../../migrations/2014_01_07_073615_create_tags_table.php' => base_path('database/migrations/2014_01_07_073615_create_tags_table.php'),
+			__DIR__.'/../../../migrations/2014_01_07_073615_create_tagged_table.php' => $this->app->databasePath('database/migrations/2014_01_07_073615_create_tagged_table.php'),
+			__DIR__.'/../../../migrations/2014_01_07_073615_create_tags_table.php' => $this->app->databasePath('database/migrations/2014_01_07_073615_create_tags_table.php'),
 		]);
 	}
 	


### PR DESCRIPTION
Some Laravel Platform like Orchestral Platform use different Folder Structure.
 The migration files are moved to <b>base_path/database/</b> according to laravel 5 folder structure. Where as in Orchestra's folder structure it needed to be moved to the path <b>base_path/resources/database/</b>. So in-order to work in different folder structure, database path should be taken instead of taking the base path. It will work seamlessly in different folder structure.