### PR TITLE
Remove hard dependency on laravel/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	],
 	"require": {
 		"php": "~5.3",
-		"laravel/framework": "~5.0"
+		"illuminate/database": "~5.0",
+		"illuminate/support": "~5.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This patch removes the hard dependency on `laravel/framework`. This will make it easy to install with Lumen, the laravel microframework