### PR TITLE
Remove unecessary calls to func_get_args

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -62,11 +62,6 @@ trait Taggable {
 	 */
 	public function tag($tagNames)
 	{
-		if(!is_array($tagNames)) {
-			$tagNames = func_get_args();
-			array_shift($tagNames);
-		}
-		
 		$tagNames = static::$taggingUtility->makeTagArray($tagNames);
 		
 		foreach($tagNames as $tagName) {
@@ -131,11 +126,6 @@ trait Taggable {
 	 */
 	public function retag($tagNames)
 	{
-		if(!is_array($tagNames)) {
-			$tagNames = func_get_args();
-			array_shift($tagNames);
-		}
-		
 		$tagNames = static::$taggingUtility->makeTagArray($tagNames);
 		$currentTagNames = $this->tagNames();
 		
@@ -157,11 +147,6 @@ trait Taggable {
 	 */
 	public function scopeWithAllTags($query, $tagNames)
 	{
-		if(!is_array($tagNames)) {
-			$tagNames = func_get_args();
-			array_shift($tagNames);
-		}
-		
 		$tagNames = static::$taggingUtility->makeTagArray($tagNames);
 		
 		$normalizer = config('tagging.normalizer');
@@ -186,11 +171,6 @@ trait Taggable {
 	 */
 	public function scopeWithAnyTag($query, $tagNames)
 	{
-		if(!is_array($tagNames)) {
-			$tagNames = func_get_args();
-			array_shift($tagNames);
-		}
-		
 		$tagNames = static::$taggingUtility->makeTagArray($tagNames);
 		
 		$normalizer = config('tagging.normalizer');


### PR DESCRIPTION
Hi,

I've suffered from the same issue as flagged up in Issue #77, where passing a single string to the `tag()` method does nothing. For example:

``` $article->tag('test'); //does nothing```

This is caused by the following code which appears in several places throughout the `Taggable.php` class:

```
if(!is_array($tagNames)) {
	$tagNames = func_get_args();
	array_shift($tagNames);
}
```

When this code runs on a method with only one argument, such as the `tag` method, it is shifting the only argument off the array, leaving nothing. For `scopeWithAllTags` and `scopeWithAnyTags` which both take two parameters,  it removes the `$query` argument, which makes sense.

It looks like this code is there to convert a string value to an array, however immediately after it in all four of the places it appears is a call to `makeTagArray` which does exactly the same thing. So this block of code is not needed, and given it's causing issues, should be removed.

This was on v2.0.4 of the code, on Laravel 5.1.20 and PHP 5.5