### PR TITLE
Hotfix: Delete Unused on untag(null) and retag(...)

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -128,9 +128,8 @@ trait Taggable {
 		$deletions = array_diff($currentTagNames, $tagNames);
 		$additions = array_diff($tagNames, $currentTagNames);
 		
-		foreach($deletions as $tagName) {
-			$this->removeTag($tagName);
-		}
+        $this->untag($deletions);
+
 		foreach($additions as $tagName) {
 			$this->addTag($tagName);
 		}

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -101,11 +101,7 @@ trait Taggable {
 	public function untag($tagNames=null)
 	{
 		if(is_null($tagNames)) {
-			$currentTagNames = $this->tagNames();
-			foreach($currentTagNames as $tagName) {
-				$this->removeTag($tagName);
-			}
-			return;
+			$tagNames = $this->tagNames();
 		}
 		
 		$tagNames = static::$taggingUtility->makeTagArray($tagNames);

--- a/src/Util.php
+++ b/src/Util.php
@@ -20,7 +20,7 @@ class Util implements TaggingUtility
 	public function makeTagArray($tagNames)
 	{
 		if(is_array($tagNames) && count($tagNames) == 1) {
-			$tagNames = $tagNames[0];
+			$tagNames = reset($tagNames);
 		}
 		
 		if(is_string($tagNames)) {


### PR DESCRIPTION
Was delete unused not called during "untag" and "retag" intentionally?