### PR TITLE
Add Auto Tagging from Property

### DIFF
--- a/config/tagging.php
+++ b/config/tagging.php
@@ -20,7 +20,11 @@ return array(
 		
 	// Auto-delete unused tags from the 'tags' database table (when they are used zero times)
 	'delete_unused_tags'=>true,
-		
+
+    // Auto-tag from property. Eg. set to 'tag_names' and set that property (ie.
+    // by using a text input in a form)
+    'auto_tag_from_prop' => false,
+
 	// Model to use to store the tags in the database
 	'tag_model'=>'\Conner\Tagging\Model\Tag',
 );

--- a/config/tagging.php
+++ b/config/tagging.php
@@ -21,10 +21,6 @@ return array(
 	// Auto-delete unused tags from the 'tags' database table (when they are used zero times)
 	'delete_unused_tags'=>true,
 
-    // Auto-tag from property. Eg. set to 'tag_names' and set that property (ie.
-    // by using a text input in a form)
-    'auto_tag_from_prop' => false,
-
 	// Model to use to store the tags in the database
 	'tag_model'=>'\Conner\Tagging\Model\Tag',
 );


### PR DESCRIPTION
Allow setting a property (eg via a form field) to use as basis of retagging or untagging.

```php
// with $autoTagFromProp = 'tag_names'
$model->tag_names = 'foo, bar';
$model->save();
```

I do something like this sometimes to be able to add the trait to a model and just add a field to a form to implement tagging. This allows me to just set a property of the model and automatically retag or untag it based on that property when just calling `Model::save()`, rather than calling retag or untag manually.

Thoughts? Concerns?
