### PR TITLE
Configurable Tagged model

### DIFF
--- a/config/tagging.php
+++ b/config/tagging.php
@@ -23,4 +23,7 @@ return array(
 
 	// Model to use to store the tags in the database
 	'tag_model'=>'\Conner\Tagging\Model\Tag',
+
+	// custom added: to determine what model to use for relations
+	'tagged_model' => '\Conner\Tagging\Model\Tagged',
 );

--- a/config/tagging.php
+++ b/config/tagging.php
@@ -24,6 +24,6 @@ return array(
 	// Model to use to store the tags in the database
 	'tag_model'=>'\Conner\Tagging\Model\Tag',
 
-	// custom added: to determine what model to use for relations
+	// Model to use for the relation between tags and tagged records
 	'tagged_model' => '\Conner\Tagging\Model\Tagged',
 );

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -59,7 +59,7 @@ trait Taggable
 	 */
 	public function tagged()
 	{
-		return $this->morphMany('Conner\Tagging\Model\Tagged', 'taggable')->with('tag');
+		return $this->morphMany(config('tagging.tagged_model', 'Conner\Tagging\Model\Tagged'), 'taggable')->with('tag');
 	}
 
 	/**


### PR DESCRIPTION
To make the `tagged()` morphMany relation configurable. This way you can roll your own Tagged model, with cache traits for instance.

My use case is a setup where I want all my queries to be cacheable, including all eager loaded relations. The `tagged()` relation for me now points to a model that has the [Rememberable](https://github.com/dwightwatson/rememberable) trait, so I can do just that.

Since the `tagging.php` config already has a configurable Tag model, this addition makes perfect sense to me.