### PR TITLE
Fix migration so you can rollback.

### DIFF
--- a/migrations/2016_06_29_073615_update_tags_table.php
+++ b/migrations/2016_06_29_073615_update_tags_table.php
@@ -19,6 +19,7 @@ class UpdateTagsTable extends Migration {
 	public function down()
 	{
 		Schema::table('tagging_tags', function ($table) {
+            $table->dropForeign('tagging_tags_tag_group_id_foreign');
 			$table->dropColumn('tag_group_id');
 		});
 	}


### PR DESCRIPTION
This fixes a bug where you cannot rollback because the foreign key constraint must first be dropped.