### PR TITLE
On Laravel 5.1.45 return only first register

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -187,7 +187,7 @@ trait Taggable
 		foreach($tagNames as $tagSlug) {
 			$tags = Tagged::where('tag_slug', call_user_func($normalizer, $tagSlug))
 				->where('taggable_type', $className)
-				->pluck('taggable_id');
+				->get()->pluck('taggable_id');
 		
 			$primaryKey = $this->getKeyName();
 			$query->whereIn($this->getTable().'.'.$primaryKey, $tags);
@@ -218,7 +218,7 @@ trait Taggable
 		
 		$tags = Tagged::whereIn('tag_slug', $tagNames)
 			->where('taggable_type', $className)
-			->pluck('taggable_id');
+			->get()->pluck('taggable_id');
 		
 		$primaryKey = $this->getKeyName();
 		return $query->whereIn($this->getTable().'.'.$primaryKey, $tags);


### PR DESCRIPTION
Apologies my english.

On L 5.1.45 

```
Tagged::whereIn('tag_slug', $tagNames)
->taggable_type', $className)
->pluck('taggable_id');
```

return only first register in string.

**Exception**
> Type error: Argument 1 passed to Illuminate\Database\Grammar::parameterize() must be of the type array, integer given, called in /home/vagrant/Code/tnonline.app/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php on line 340

**SQL Return:**
`select `taggable_id` from `tagging_tagged` where `tag_slug` in ('eleicoes-2016') and `taggable_type` = 'App\Noticias' limit 1`

