### PR TITLE
Feature: add a short description to the tag

### DIFF
--- a/migrations/2014_01_07_073615_create_tags_table.php
+++ b/migrations/2014_01_07_073615_create_tags_table.php
@@ -11,6 +11,7 @@ class CreateTagsTable extends Migration
 			$table->increments('id');
 			$table->string('slug', 125)->index();
 			$table->string('name', 125);
+			$table->text('description')->nullable();
 			$table->boolean('suggest')->default(false);
 			$table->integer('count')->unsigned()->default(0); // count of how many times this tag was used
             $table->integer('tag_group_id')->unsigned()->nullable();

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property integer count
  * @property integer tag_group_id
  * @property TagGroup group
+ * @property string description
  * @method static suggested()
  * @method static inGroup(string $group)
  */
@@ -22,7 +23,7 @@ class Tag extends Model
 {
     protected $table = 'tagging_tags';
     public $timestamps = false;
-    public $fillable = ['name'];
+    public $fillable = ['name', 'description'];
 
     /**
      * @param array $attributes

--- a/tests/TagBaseTest.php
+++ b/tests/TagBaseTest.php
@@ -15,4 +15,19 @@ class TagBaseTest extends BaseTestCase
         $this->assertEquals('Foobar', $tag->name);
         $this->assertEquals('foobar', $tag->slug);
     }
+
+    public function test_it_can_have_a_description()
+    {
+        $description = 'Fooobar test description';
+        $tag = new Tag([
+            'name' => 'foobar',
+            'description' => $description
+        ]);
+
+        $tag->save();
+
+        $this->assertEquals('Foobar', $tag->name);
+        $this->assertEquals('foobar', $tag->slug);
+        $this->assertEquals($description, $tag->description);
+    }
 }


### PR DESCRIPTION
As requested in #174, this PR adds a `description` optional field to the tag model. It should fixes #174.