### PR TITLE
Performance Improvement when querying tags on model especially for models with lots of records and with tags

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -205,7 +205,8 @@ trait Taggable
                 ->where('tag_slug', TaggingUtility::normalize($tagSlug))
                 ->where('taggable_type', $className)
                 ->get()
-                ->pluck('taggable_id');
+                ->pluck('taggable_id')
+                ->unique();
 
             $primaryKey = $this->getKeyName();
             $query->whereIn($this->getTable().'.'.$primaryKey, $tags);
@@ -401,7 +402,8 @@ trait Taggable
             ->whereIn('tag_slug', $tagNames)
             ->where('taggable_type', $className)
             ->get()
-            ->pluck('taggable_id');
+            ->pluck('taggable_id')
+            ->unique();
 
         return $tags;
     }


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### Issues
When using laravel-tagging with models that has tags but lots of records, there is a performance issues when using withAnyTags to retrieve particular models with specific tags. The 'where In' clause for the query will also show duplicate TagIds in the resulting eloquent queries. 

#### What does this implement/fix? Explain your changes.
In the codes where it pluck('taggable_id'), I've included laravel collection method unique() to remove this duplicate TagIds. This reduce the number of tags included in the 'Where In' clause of the model and increase performance by roughly 40%. 

#### Any other comments?
No