### PR TITLE
Add Support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
   ],
   "require": {
     "php": "^7.3|^8.0",
-    "illuminate/database": "^8.67|^9.0|^10.0|^11.0",
-    "illuminate/support": "^8.67|^9.0|^10.0|^11.0"
+    "illuminate/database": "^8.67|^9.0|^10.0|^11.0|^12.0",
+    "illuminate/support": "^8.67|^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^9.8.0",
-    "phpunit/phpunit": "10.5.39",
+    "orchestra/testbench": "^9.8.0|^10.0",
+    "phpunit/phpunit": "10.5.39|^11.0",
     "mockery/mockery": "1.*",
     "laravel/pint": "^1.18"
   },


### PR DESCRIPTION
- Update `composer.json` Laravel versions to 

Using this package? If you would like to help test these changes or believe them to be compatible, you may update your project to reference this branch.

To do so, temporarily add the fork to the repositories property of your `composer.json`:

```json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/nickfls/laravel-tagging.git"
        }
    ]
}
```
Then update your dependency constraint to reference this branch:

```json
{
    "require": {
        "rtconner/laravel-tagging":"dev-add-laravel-12-compatibility",
    }
}
```
Finally, run: `composer update` 

To validate, run `php ./vendor/bin/phpunit`﻿
